### PR TITLE
Bump nodejs version and clarify instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
 # PCS WEB UI
 
-Web interface for [pcs](https://github.com/ClusterLabs/pcs) - a Corosync and
+Web interface for [pcs] - a Corosync and
 Pacemaker configuration tool.
 
 It can run in two modes:
-* a standalone application (provided by `pcsd` backend)
+* a standalone application (provided by `pcsd` backend from [pcs])
 * a cockpit plugin
 
 ## Prerequisites
 
-* [Node.js](http://nodejs.org/) v16.14.0+ (with NPM)
+* [Node.js](http://nodejs.org/) v18+ (with NPM)
 * autoconf, automake
 * pkgconf
-* [pcs](https://github.com/ClusterLabs/pcs)
+* [pcs]
 * [cockpit](https://cockpit-project.org/) (optional)
 
 ## Building and installation
@@ -32,5 +32,12 @@ You can add following flags to `./configure`:
 
 * `--disable-cockpit` to disable cockpit installation
 * `--disable-standalone` to disable standalone installation
-* `-- with-pcsd-webui-dir` to specify standalone installation directory
+* `--with-pcsd-webui-dir` to specify standalone installation directory
 * `--with-cockpit-dir` to specify cockpit plugin installation directory
+
+Make sure to also install pcs if you haven't installed it yet. Pcsd needs to be running in order for pcs-web-ui to work, even for the cockpit plugin:
+```sh
+systemctl enable --now pcsd
+```
+
+[pcs]: https://github.com/ClusterLabs/pcs


### PR DESCRIPTION
- nodejs 18 is required by one of the node modules
- clarify that pcsd must be running for pcs-web-ui must work
- remove extra space from configure option