### PR TITLE
Add screenshots to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Pacemaker configuration tool.
 
 It can run in two modes:
 * a standalone application (provided by `pcsd` backend from [pcs])
-* a cockpit plugin
+* a [cockpit] plugin
 
 ## Prerequisites
 
@@ -13,7 +13,7 @@ It can run in two modes:
 * autoconf, automake
 * pkgconf
 * [pcs]
-* [cockpit](https://cockpit-project.org/) (optional)
+* [cockpit] (optional)
 
 ## Building and installation
 
@@ -41,3 +41,4 @@ systemctl enable --now pcsd
 ```
 
 [pcs]: https://github.com/ClusterLabs/pcs
+[cockpit]: https://cockpit-project.org/

--- a/README.md
+++ b/README.md
@@ -4,8 +4,11 @@ Web interface for [PCS] - a Corosync and
 Pacemaker configuration tool.
 
 It can run in two modes:
-* a standalone application (provided by `pcsd` backend from [pcs])
-* a [Cockpit] plugin
+| a standalone application <br> (provided by `pcsd` backend from [pcs]) | a [Cockpit] plugin |
+|:---:|:---:|
+| <img width="400" height="auto" alt="Image" src="https://github.com/user-attachments/assets/af54d3d2-d5d6-4f51-b8f3-8c1dc502f575" /> | <img width="400" height="auto" alt="Image" src="https://github.com/user-attachments/assets/fc638b75-7d0e-4cc4-be53-b3f155aadd5a" /> |
+
+More screenshots can be found here: https://github.com/ClusterLabs/pcs-web-ui/issues/81
 
 ## Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -1,23 +1,23 @@
-# PCS WEB UI
+# PCS Web UI
 
-Web interface for [pcs] - a Corosync and
+Web interface for [PCS] - a Corosync and
 Pacemaker configuration tool.
 
 It can run in two modes:
 * a standalone application (provided by `pcsd` backend from [pcs])
-* a [cockpit] plugin
+* a [Cockpit] plugin
 
 ## Prerequisites
 
 * [Node.js](http://nodejs.org/) v18+ (with NPM)
 * autoconf, automake
 * pkgconf
-* [pcs]
-* [cockpit] (optional)
+* [PCS]
+* [Cockpit] (optional)
 
 ## Building and installation
 
-To install pcs-web-ui run the following in terminal:
+To install PCS Web UI run the following in terminal:
 
 ```sh
 ./autogen.sh
@@ -35,10 +35,10 @@ You can add following flags to `./configure`:
 * `--with-pcsd-webui-dir` to specify standalone installation directory
 * `--with-cockpit-dir` to specify cockpit plugin installation directory
 
-Make sure to also install pcs if you haven't installed it yet. Pcsd needs to be running in order for pcs-web-ui to work, even for the cockpit plugin:
+Make sure to also install PCS if you haven't installed it yet. Pcsd needs to be running in order for PCS Web UI to work, even for the Cockpit plugin:
 ```sh
 systemctl enable --now pcsd
 ```
 
-[pcs]: https://github.com/ClusterLabs/pcs
-[cockpit]: https://cockpit-project.org/
+[PCS]: https://github.com/ClusterLabs/pcs
+[Cockpit]: https://cockpit-project.org/


### PR DESCRIPTION
I actually decided to put at least some screenshots in the README since users don't really like clicking through pages. I decided to use the opportunity of listing the operation modes to add the screenshots in a very space efficient way.  I also verified that this approach scales nicely as the window resizes. 

For additional screenshots, I used the issue link. I edited the issue to also include the same cluster overview screenshot from Cockpit to have a direct comparison. This screenshot is hidden in the issue by setting the `<img>` element size to 0.

I also made some other improvements in-line with the upcoming announcements...